### PR TITLE
add inlineSources ts option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
         "removeComments": true,
         "declaration": true,
         "sourceMap": true,
-        "jsx": "react"
+        "jsx": "react",
+        "inlineSources": true
     },
     "include": [
         "./src/**/*.tsx",


### PR DESCRIPTION
Hi!

The generated source map is referencing the `Emoji.tsx` file, which is not present in the published version of the package. This triggers an error when building a package depending on `a11y-react-emoji`:

```
./myPackage/node_modules/a11y-react-emoji/src/Emoji.js
Failed to parse source map from 'myPackage/node_modules/a11y-react-emoji/src/Emoji.tsx' file: Error: ENOENT: no such file or directory, open 'myPackage/node_modules/a11y-react-emoji/src/Emoji.tsx'
 @ myPackage/node_modules/a11y-react-emoji/src/index.js 6:9-27 7:14-32
```

This can be fixed by adding the `inlineSources` option to `tsconfig.json`.

Link to the added option documentation:
https://www.typescriptlang.org/tsconfig/#inlineSources

It's basicaly adding this line at the end of the Emoji.js file:

```js
//# sourceMappingURL=Emoji.js.map
```
